### PR TITLE
finished audio transcriptions

### DIFF
--- a/completion.go
+++ b/completion.go
@@ -72,6 +72,10 @@ type ChatCompletion struct {
 	Stream chan *ChatChunkCompletion `json:"-"`
 }
 
+type Transcript struct {
+	Text string `json:"text"`
+}
+
 type ErrorResponse struct {
 	Error Error `json:"error"`
 }


### PR DESCRIPTION
Nothing too crazy here. The only notable part is the switch in client.go at L112. This is necessary to prevent breaking when ReponseFormat "text" is defined. This logic may be useful to transfer to chat completions as well, if no such logic is already implemented.

I'm open to questions and changes, and would appreciate a fast merge so that I can update my dependants accordingly. 